### PR TITLE
Fix: TODO-list

### DIFF
--- a/TODOs/weekly_goals.md
+++ b/TODOs/weekly_goals.md
@@ -4,42 +4,44 @@
 
 ### Week 2
 
-#### Goals: 
+#### Goals:
+
 DeepSynergy:
-- rewrite DeepSynergy to pytorch
-- Understand input for DS (DeepSynergy) mostly (with biological details) and present to group
+
+-   rewrite DeepSynergy to PyTorch
+-   Understand input for DS (DeepSynergy) mostly (with biological details) and present to group
+
 DeepSignalingFlow:
-- Understand input for DSF (DeepSignalingFlow) mostly (with biological details) and present to group
-- Understanding all the operations of DFS with corresponding code pieces and present to group
-  - copy DSF elements to our github
+
+-   Understand input for DSF (DeepSignalingFlow) mostly (with biological details) and present to group
+-   Understanding all the operations of DSF with corresponding code pieces and present to group
+    -   copy DSF elements to our GitHub
+
 Both:
-- understand validation standard (leave blablabla out) for data leakage free validation
-  - test with DS
+
+-   understand validation standard (leave blablabla out) for data leakage free validation
+    -   test with DS
 
 #### Table Week 2
 
-### Week 2
+| Names     | Tasks | Time Taken |
+| --------- | ----- | ---------- |
+| Michael F |
 
-#### Goals: 
-DeepSynergy:
-- rewrite DeepSynergy to PyTorch
-- Understand input for DS (DeepSynergy) mostly (with biological details) and present to group
+Hier kommst rein, was Michael F. macht
+| Time |
+| Sebastian |
+Reading into Neural Networks <br>
+Translated DeepSynergy from Tensorflow to Pytorch (need review) <br>
+DeepSynergy Modell trainiert <br>
+| 20h |
+| Olha |
 
-DeepSignalingFlow:
-- Understand input for DSF (DeepSignalingFlow) mostly (with biological details) and present to group
-- Understanding all the operations of DSF with corresponding code pieces and present to group
-  - copy DSF elements to our GitHub
+| Time |
+| Zhao |
 
-Both:
-- understand validation standard (leave blablabla out) for data leakage free validation
-  - test with DS
-
----
-
-| Names      | Tasks                                                                                                                                                                                                                                                                                     | Time Taken |
-|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------|
-| Michael F  | Cell 2                                                                                                                                                                                                                                                                                     | Cell 5     |
-| Sebastian  | Einlesung in neuronale Netzwerke. DeepSynergy von TensorFlow nach PyTorch übertragen → Architektur (`model.py`) manuell in PyTorch mit `nn.Sequential` nachgebaut. Datensatz verarbeitet & geladen → `data_test_fold0_tanh.p` erfolgreich mit `pickle` eingelesen, in `TensorDataset` umgewandelt. Trainings-Pipeline in PyTorch erstellt & ausgeführt → `train.py` mit Trainings- und Validierungsschleife programmiert und mit realen Daten (mehrstündiger Lauf) trainiert. Data-Leakage-Prüfsystem entwickelt → `check_data_leakage.py` erstellt, AB/BA-Kombinationen identifiziert (Test- & Echtversion vorbereitet). Struktur zur Wiederverwendbarkeit vorbereitet → Modell speichern mit `torch.save`, Planung für GitHub-Integration und Re-Loading. | 20h        |
-| Olha       | Cell 12                                                                                                                                                                                                                                                                                    | Cell 15    |
-| Zhao       | Cell 17                                                                                                                                                                                                                                                                                    | Cell 20    |
-| Michael M  | Repository-Struktur aufgebaut & Koordination → Projektordner erstellt, zentrale Dateien organisiert und Pull-Request-Strategie vorbereitet                                                                                                                                                | Cell 25    |
+| Time |
+| Michael M |
+Make and Organize Repository <br>
+Write Docs for standards in code/workflow
+| Time |


### PR DESCRIPTION
Fixes our Todo list to be editable and readable in markdown for future changes. 
Removed double copying.
Switched to english and summarized.